### PR TITLE
require DrawHistory.pushDraw enforces sequential draws

### DIFF
--- a/contracts/DrawHistory.sol
+++ b/contracts/DrawHistory.sol
@@ -104,10 +104,10 @@ contract DrawHistory is IDrawHistory, OwnerOrManager {
   /**
     * @notice External function to get the last draw.
     * @dev    External function to get the last draw using the nextDrawIndex.
-    * @return Draw index
+    * @return Last draw
   */
   function getLastDraw() external view returns (DrawLib.Draw memory) {
-    return _getLastDraw();
+    return _getLastDraw(nextDrawIndex);
   }
 
   /**
@@ -132,7 +132,7 @@ contract DrawHistory is IDrawHistory, OwnerOrManager {
   }
 
   /* ============ Internal Functions ============ */
-  
+
   /**
     * @notice Internal function to calculate draw index using the draw id.
     * @dev    Use the draw id to calculate the draw index position in the draws ring buffer.
@@ -160,17 +160,14 @@ contract DrawHistory is IDrawHistory, OwnerOrManager {
   /**
     * @notice Internal function to get the last draw.
     * @dev    Internal function to get the last draw using the nextDrawIndex.
-    * @return Draw index
+    * @return Last draw
   */
-  function _getLastDraw() internal view returns (DrawLib.Draw memory) {
-    uint32 _nextDrawIndex = nextDrawIndex;
-    DrawLib.Draw memory _lastDraw;
+  function _getLastDraw(uint256 _nextDrawIndex) internal view returns (DrawLib.Draw memory) {
     if(_nextDrawIndex == 0) {
-      _lastDraw = _draws[CARDINALITY - 1];
+      return _draws[CARDINALITY - 1];
     } else {
-      _lastDraw = _draws[_nextDrawIndex - 1];
+      return _draws[_nextDrawIndex - 1];
     }
-    return _lastDraw;
   }
 
   /**
@@ -181,12 +178,9 @@ contract DrawHistory is IDrawHistory, OwnerOrManager {
   */
   function _pushDraw(DrawLib.Draw memory _newDraw) internal returns (uint32) {
     uint32 _nextDrawIndex = nextDrawIndex;
-    DrawLib.Draw memory _lastDraw = _getLastDraw();
-    // Without an existing draw history check the next draw is sequential. Else check the first draw id is 0.
-    if(_lastDraw.timestamp != 0) {
+    DrawLib.Draw memory _lastDraw = _getLastDraw(_nextDrawIndex);
+    if (_lastDraw.timestamp != 0) {
       require(_newDraw.drawId == _lastDraw.drawId + 1, "DrawHistory/nonsequential-draw");
-    } else {
-      require(_newDraw.drawId == 0, "DrawHistory/first-drawid-must-be-zero");
     }
     _draws[_nextDrawIndex] = _newDraw;
     emit DrawSet(_nextDrawIndex, _newDraw.drawId, _newDraw.timestamp, _newDraw.winningRandomNumber);

--- a/test/DrawHistory.test.ts
+++ b/test/DrawHistory.test.ts
@@ -3,7 +3,7 @@ import { ethers } from 'hardhat';
 import { constants, Contract, ContractFactory } from 'ethers';
 const { getSigners } = ethers;
 const { AddressZero } = constants;
-describe.only('DrawHistory', () => {
+describe('DrawHistory', () => {
   let wallet1: any;
   let wallet2: any;
   let wallet3: any;
@@ -34,7 +34,6 @@ describe.only('DrawHistory', () => {
         expect(draw.drawId).to.equal(0)
         expect(draw.timestamp).to.equal(0)
         expect(draw.winningRandomNumber).to.equal(0)
-
       }
     });
   })


### PR DESCRIPTION
Includes fixes for two issues:

- https://linear.app/pooltogether/issue/POOL-1481/drawhistory-pushdraw-must-require-that-draw-ids-are-sequential
- https://linear.app/pooltogether/issue/POOL-1480/need-a-fxn-to-get-most-recent-draw-from-drawhistory