### PR TITLE
wip for users claimed history

### DIFF
--- a/contracts/DrawHistory.sol
+++ b/contracts/DrawHistory.sol
@@ -89,20 +89,20 @@ contract DrawHistory is IDrawHistory, OwnerOrManager {
   }
 
   /**
-    * @notice External function to get the newest draw.
-    * @dev    External function to get the newest draw using the nextDrawIndex.
-    * @return Newest draw
+    * @notice Retrieve the newest draw within the cardinality range.
+    * @dev    Retrieve the newest draw within the cardinality range.
+    * @return Draw
   */
-  function getNewestDraw() external view returns (DrawLib.Draw memory) {
+  function getNewestDraw() external view override returns (DrawLib.Draw memory) {
     return _getNewestDraw(nextDrawIndex);
   }
 
   /**
-    * @notice Function to get the oldest draw.
-    * @dev    Function to get the oldest draw using the totalDraws.
-    * @return Last draw
+    * @notice Retrieve the oldest draw within the cardinality range.
+    * @dev    Retrieve the oldest draw within the cardinality range.
+    * @return Draw
   */
-  function getOldestDraw() external view returns (DrawLib.Draw memory) {
+  function getOldestDraw() external view override returns (DrawLib.Draw memory) {
     uint256 _totalDraws = totalDraws;
     uint256 _nextDrawIndex = nextDrawIndex;
     if(_totalDraws < CARDINALITY) {

--- a/contracts/interfaces/IDrawHistory.sol
+++ b/contracts/interfaces/IDrawHistory.sol
@@ -22,6 +22,8 @@ interface IDrawHistory {
   function drawIdToDrawIndex(uint32 drawId) external view returns(uint32);
   function getDraws(uint32[] calldata drawIds) external view returns (DrawLib.Draw[] memory);
   function getDraw(uint32 drawId) external view returns (DrawLib.Draw memory);
+  function getNewestDraw() external view returns (DrawLib.Draw memory);
+  function getOldestDraw() external view returns (DrawLib.Draw memory);
   function pushDraw(DrawLib.Draw calldata draw) external returns(uint32);
   function setDraw(uint256 drawIndex, DrawLib.Draw calldata draw) external returns(uint32); // maybe return drawIndex
 }

--- a/contracts/test/ClaimableDrawHarness.sol
+++ b/contracts/test/ClaimableDrawHarness.sol
@@ -7,10 +7,6 @@ import "../interfaces/IDrawCalculator.sol";
 
 contract ClaimableDrawHarness is ClaimableDraw {
   
-  function drawIdToClaimIndex(uint8 drawId) external pure returns (uint256) {
-    return _drawIdToClaimIndex(drawId);
-  } 
-
   function calculateDrawCollectionPayout(
     address _user,
     uint96[PAYOUT_CARDINALITY] memory _userClaimedDraws, 
@@ -21,6 +17,15 @@ contract ClaimableDrawHarness is ClaimableDraw {
     return _calculateDrawCollectionPayout(_user, _userClaimedDraws, _drawIds, _drawCalculator, _data);
   } 
 
+  function resetUserDrawClaimedHistory(uint32 _resetPosition, uint32 _resetAmount, uint96[PAYOUT_CARDINALITY] memory _claimHistory) external returns (uint96[PAYOUT_CARDINALITY] memory) {
+    userPayoutHistory[msg.sender] = _claimHistory;
+    uint96[PAYOUT_CARDINALITY] memory _newClaimHistory = _resetUserDrawClaimedHistory(_resetPosition, _resetAmount, _claimHistory);
+    userPayoutHistory[msg.sender] = _newClaimHistory;
+  } 
+
+  function validateDrawIdRange(uint32[] calldata _drawIds, DrawLib.Draw memory _newestDrawFromHistory) external pure returns (bool) {
+    return _validateDrawIdRange(_drawIds, _newestDrawFromHistory);
+  } 
 
   function validateDrawPayout(
     uint96[PAYOUT_CARDINALITY] memory _userClaimedDraws, 
@@ -30,9 +35,17 @@ contract ClaimableDrawHarness is ClaimableDraw {
     return _validateDrawPayout(_userClaimedDraws, _drawId, _payout);
   } 
 
+  function wrapCardinality(uint8 drawId) external pure returns (uint256) {
+    return _wrapCardinality(drawId);
+  } 
+
   function setUserDrawPayoutHistory(address user, uint96[PAYOUT_CARDINALITY] memory userClaimedDraws) external returns (bool) {
     userPayoutHistory[user] = userClaimedDraws;
     return true;
   } 
+  
+  function simulateResetingDrawHistory(address user, uint96[PAYOUT_CARDINALITY] memory userClaimedDraws) external returns (bool) {
+
+  }
 
 }


### PR DESCRIPTION
To store the highest `userHighestClaimedDrawIndex` added drawIndex to the Draw struct, so when ClaimableDraw requests draws the Draw struct will already have its current drawIndex. Or... instead of using drawIndex just revert back to drawId as indicator high the most recent draw?  

The biggest question I have is how we handle `PAYOUT_CARDINALITY` in relation to DrawHistory `CARDINALITY`

Seems like the best path forward is to allow users to claim PAYOUT_CARDINALITY draws in the past from the current highest draw?
 