### PR TITLE
fix(TwabLib): prevent account.cardianlity from exceeding max cardinality

### DIFF
--- a/contracts/libraries/TwabLib.sol
+++ b/contracts/libraries/TwabLib.sol
@@ -362,8 +362,15 @@ library TwabLib {
         _accountDetails.nextTwabIndex = uint24(
             RingBufferLib.nextIndex(_accountDetails.nextTwabIndex, MAX_CARDINALITY)
         );
-
-        _accountDetails.cardinality += 1;
+        
+        // Prevent the Account specific cardinality from exceeding the MAX_CARDINALITY.
+        // The ring buffer length is limited by MAX_CARDINALITY. IF the account.cardinality
+        // exceeds the max cardinality, new observations would be incorrectly set or the
+        // observation would be out of "bounds" of the ring buffer. Once reached the
+        // AccountDetails.cardinality will continue to be equal to max cardinality.
+        if(_accountDetails.cardinality < MAX_CARDINALITY) {
+            _accountDetails.cardinality += 1;
+        }
 
         return (_accountDetails, newTwab, true);
     }

--- a/contracts/libraries/TwabLib.sol
+++ b/contracts/libraries/TwabLib.sol
@@ -359,10 +359,19 @@ library TwabLib {
 
         _twabs[_accountDetails.nextTwabIndex] = newTwab;
 
+        _accountDetails = push(_accountDetails);
+
+        return (_accountDetails, newTwab, true);
+    }
+
+    /// @notice "Pushes" a new element on the AccountDetails ring buffer, and returns the new AccountDetails
+    /// @param _accountDetails The account details from which to pull the cardinality and next index
+    /// @return The new AccountDetails
+    function push(AccountDetails memory _accountDetails) internal pure returns (AccountDetails memory) {
         _accountDetails.nextTwabIndex = uint24(
             RingBufferLib.nextIndex(_accountDetails.nextTwabIndex, MAX_CARDINALITY)
         );
-        
+
         // Prevent the Account specific cardinality from exceeding the MAX_CARDINALITY.
         // The ring buffer length is limited by MAX_CARDINALITY. IF the account.cardinality
         // exceeds the max cardinality, new observations would be incorrectly set or the
@@ -372,6 +381,6 @@ library TwabLib {
             _accountDetails.cardinality += 1;
         }
 
-        return (_accountDetails, newTwab, true);
+        return _accountDetails;
     }
 }

--- a/contracts/test/TwabLibraryExposed.sol
+++ b/contracts/test/TwabLibraryExposed.sol
@@ -107,4 +107,8 @@ contract TwabLibExposed {
     function getBalanceAt(uint32 _target, uint32 _currentTime) external view returns (uint256) {
         return TwabLib.getBalanceAt(account.twabs, account.details, _target, _currentTime);
     }
+
+    function push(TwabLib.AccountDetails memory _accountDetails) external pure returns (TwabLib.AccountDetails memory) {
+        return TwabLib.push(_accountDetails);
+    }
 }

--- a/test/TwabLibraryExposed.test.ts
+++ b/test/TwabLibraryExposed.test.ts
@@ -1,6 +1,6 @@
 import { SignerWithAddress } from '@nomiclabs/hardhat-ethers/signers';
 import { expect } from 'chai';
-import { utils, Contract, ContractFactory } from 'ethers';
+import { utils, Contract, ContractFactory, BigNumber } from 'ethers';
 import { ethers } from 'hardhat';
 
 const { getSigners } = ethers;
@@ -298,4 +298,24 @@ describe('TwabLib', () => {
             });
         });
     });
+
+    describe('push()', () => {
+        it('should increment the cardinality', async () => {
+            const result = await twabLib.push({ balance: '0', nextTwabIndex: 2, cardinality: 10 })
+            expect(
+                result.map((obj: any) => obj.toString())
+            ).to.deep.equals(
+                [ '0', '3', `11` ]
+            )
+        })
+
+        it('should correctly limit the cardinality', async () => {
+            const result = await twabLib.push({ balance: '0', nextTwabIndex: 2, cardinality: 2**24-1 })
+            expect(
+                result.map((obj: any) => obj.toString())
+            ).to.deep.equals(
+                [ '0', '3', `${2**24-1}` ]
+            )
+        })
+    })
 });


### PR DESCRIPTION
Prevent the Account specific cardinality from exceeding the MAX_CARDINALITY. The ring buffer length is limited by MAX_CARDINALITY. IF the account.cardinality exceeds the max cardinality, new observations would be incorrectly set or the 
 observation would be out of "bounds" of the ring buffer.

Once reached the AccountDetails.cardinality will continue to be equal to max cardinality.