### PR TITLE
bug(Reserve): move withdrawAccumulator above external transfer call. …

### DIFF
--- a/contracts/Reserve.sol
+++ b/contracts/Reserve.sol
@@ -97,8 +97,9 @@ contract Reserve is IReserve, Manageable {
     function withdrawTo(address _recipient, uint256 _amount) external override onlyManagerOrOwner {
         _checkpoint();
 
-        token.safeTransfer(_recipient, _amount);
         withdrawAccumulator += uint224(_amount);
+        
+        token.safeTransfer(_recipient, _amount);
 
         emit Withdrawn(_recipient, _amount);
     }


### PR DESCRIPTION
Move `withdrawAccumulator += uint224(_amount);` above `token.safeTransfer(_recipient, _amount);` to protect against a malicious call to the `token.transfer` function manipulating `withdrawTo`.