### PR TITLE
optimization(PrizeFliush): reuse existing external call value

### DIFF
--- a/contracts/PrizeFlush.sol
+++ b/contracts/PrizeFlush.sol
@@ -118,10 +118,8 @@ contract PrizeFlush is IPrizeFlush, Manageable {
         uint256 _amount = _token.balanceOf(address(_reserve));
 
         if (_amount > 0) {
-            // Create checkpoint and transfers new total balance to DrawPrize
             address _destination = destination;
-            _reserve.withdrawTo(_destination, _token.balanceOf(address(_reserve)));
-
+            _reserve.withdrawTo(_destination, _amount);
             emit Flushed(_destination, _amount);
         }
 


### PR DESCRIPTION
Use `uint256 _amount = _token.balanceOf(address(_reserve));` parameter when calling `_reserve.withdrawTo(_destination, _amount);`