### PR TITLE
Added casting in support of PrizeDistribution struct

### DIFF
--- a/contracts/libraries/ExtendedSafeCastLib.sol
+++ b/contracts/libraries/ExtendedSafeCastLib.sol
@@ -18,6 +18,22 @@ pragma solidity 0.8.6;
  * all math on `uint256` and `int256` and then downcasting.
  */
 library ExtendedSafeCastLib {
+
+    /**
+     * @dev Returns the downcasted uint104 from uint256, reverting on
+     * overflow (when the input is greater than largest uint104).
+     *
+     * Counterpart to Solidity's `uint104` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 104 bits
+     */
+    function toUint104(uint256 _value) internal pure returns (uint104) {
+        require(_value <= type(uint104).max, "SafeCast: value doesn't fit in 104 bits");
+        return uint104(_value);
+    }
+
     /**
      * @dev Returns the downcasted uint208 from uint256, reverting on
      * overflow (when the input is greater than largest uint208).

--- a/contracts/test/libraries/ExtendedSafeCastLibHarness.sol
+++ b/contracts/test/libraries/ExtendedSafeCastLibHarness.sol
@@ -7,7 +7,15 @@ import "../../libraries/ExtendedSafeCastLib.sol";
 contract ExtendedSafeCastLibHarness {
     using ExtendedSafeCastLib for uint256;
 
+    function toUint104(uint256 value) external pure returns (uint104) {
+        return value.toUint104();
+    }
+
     function toUint208(uint256 value) external pure returns (uint208) {
         return value.toUint208();
+    }
+
+    function toUint224(uint256 value) external pure returns (uint224) {
+        return value.toUint224();
     }
 }

--- a/test/libraries/ExtendedSafeCast.test.ts
+++ b/test/libraries/ExtendedSafeCast.test.ts
@@ -14,6 +14,21 @@ describe('ExtendedSafeCastLib', () => {
         ExtendedSafeCastLib = await ExtendedSafeCastLibFactory.deploy();
     });
 
+    describe('toUint104()', () => {
+        it('should return uint256 downcasted to uint104', async () => {
+            const value = toWei('1');
+
+            expect(await ExtendedSafeCastLib.toUint104(value)).to.equal(value);
+        });
+        it('should fail to return value if value passed does not fit in 104 bits', async () => {
+            const value = BigNumber.from(2).pow(104);
+
+            await expect(ExtendedSafeCastLib.toUint104(value)).to.be.revertedWith(
+                "SafeCast: value doesn't fit in 104 bits",
+            );
+        });
+    });
+
     describe('toUint208()', () => {
         it('should return uint256 downcasted to uint208', async () => {
             const value = toWei('1');
@@ -25,6 +40,22 @@ describe('ExtendedSafeCastLib', () => {
 
             await expect(ExtendedSafeCastLib.toUint208(value)).to.be.revertedWith(
                 "SafeCast: value doesn't fit in 208 bits",
+            );
+        });
+    });
+
+    describe('toUint224()', () => {
+        it('should return uint256 downcasted to uint224', async () => {
+            const value = toWei('1');
+
+            expect(await ExtendedSafeCastLib.toUint224(value)).to.equal(value);
+        });
+
+        it('should fail to return value if value passed does not fit in 208 bits', async () => {
+            const value = BigNumber.from(2).pow(224);
+
+            await expect(ExtendedSafeCastLib.toUint224(value)).to.be.revertedWith(
+                "SafeCast: value doesn't fit in 224 bits",
             );
         });
     });


### PR DESCRIPTION
See [pool-1905-move-prizedistribution-calculation-on](https://linear.app/pooltogether/issue/POOL-1905/move-prizedistribution-calculation-on-chain)